### PR TITLE
Allow not supplying a path argument to audit the whole store

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ including but not limited to:
 ## Usage
 
 ```
-usage: pass audit [-h] [-V] paths
+usage: pass audit [-h] [-V] [paths]
 
   A pass extension for auditing your password repository. It supports safe
   breached password detection from haveibeenpwned.com using K-anonymity method.

--- a/lib/audit.py
+++ b/lib/audit.py
@@ -222,7 +222,8 @@ def main(argv):
 
     # Sanity checks
     if arg.paths is None:
-        die("pass-names not present. See 'pass audit -h'")
+        arg.paths = ""
+        message("Auditing whole store - this may take some time")
     store = PasswordStore()
     if not store.exist():
         die("no password store to audit.")

--- a/pass-audit.1
+++ b/pass-audit.1
@@ -5,7 +5,7 @@
 
 
 .SH SYNOPSIS
-\fBpass audit\fP [-h] [-V] paths
+\fBpass audit\fP [-h] [-V] [paths]
 
 .SH DESCRIPTION
 \fBpass audit\fP is a password store extension for auditing your password

--- a/tests/30_pass_audit.py
+++ b/tests/30_pass_audit.py
@@ -44,7 +44,7 @@ class TestPassAuditCMD(setup.TestPass):
     def test_pass_audit_PathsNotPresent(self):
         """Testing: empty paths."""
         cmd = []
-        self._passaudit(cmd, 1)
+        self._passaudit(cmd)
 
     def test_pass_audit_NotAnOption(self):
         """Testing: pass audit --not-an-option."""


### PR DESCRIPTION
It seems like a reasonable use case would be to run an audit on the entire password store to check all of them at once. I removed the check on the paths argument so that ``pass audit`` would audit the entire store.

This took a while on my store (and I would imagine any large store), which lead me to wonder if it was working correctly, so I also added a message about the possibility of the audit taking a long time.