### PR TITLE
test passwords against zxcvbn

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "zxcvbn-python"]
+	path = zxcvbn-python
+	url = https://github.com/dwolfhub/zxcvbn-python

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "zxcvbn-python"]
-	path = zxcvbn-python
-	url = https://github.com/dwolfhub/zxcvbn-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - wget https://git.zx2c4.com/password-store/snapshot/password-store-$PASS_VERSION.tar.xz
   - tar -xf password-store-$PASS_VERSION.tar.xz
   - make --directory=password-store-$PASS_VERSION install
-  - pip3 install green coverage codacy-coverage requests
+  - pip3 install green coverage codacy-coverage requests zxcvbn
 
 script:
   - make tests

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,12 @@ all:
 	@echo "     password store"
 	@echo "     python3"
 	@echo "     python3-requests"
+	@echo "     zxcvbn-python (either install with 'pip3 install zxcvbn' or locally with 'make zxcvbn')"
+
+zxcvbn:
+	git submodule add https://github.com/dwolfhub/zxcvbn-python || git submodule init zxcvbn-python
+	@install -v -d "$(DESTDIR)$(EXTENSION_LIB)/"
+	cp -r "zxcvbn-python/zxcvbn/" "$(DESTDIR)$(EXTENSION_LIB)/"
 
 install:
 	@install -v -d "$(DESTDIR)$(MANDIR)/man1"
@@ -23,7 +29,6 @@ install:
 	@trap 'rm -f .audit.bash' EXIT; sed "s|/usr/lib|$(LIBDIR)|" "$(PROG).bash" > ".$(PROG).bash" && \
 	install -v -m 0755 ".$(PROG).bash" "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/$(PROG).bash"
 	@install -v -m 0755 "lib/$(PROG).py" "$(DESTDIR)$(EXTENSION_LIB)/$(PROG).py"
-	cp -r "zxcvbn-python/zxcvbn/" "$(DESTDIR)$(EXTENSION_LIB)/"
 	@install -v -m 0644 "pass-$(PROG).1" "$(DESTDIR)$(MANDIR)/man1/pass-$(PROG).1"
 	@echo
 	@echo "pass-$(PROG) is installed succesfully"
@@ -44,4 +49,4 @@ lint:
 clean:
 	@rm -vrf tests/test-results/ tests/gnupg/random_seed
 
-.PHONY: install uninstall tests lint clean
+.PHONY: zxcvbn install uninstall tests lint clean

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,7 @@ all:
 	@echo "     password store"
 	@echo "     python3"
 	@echo "     python3-requests"
-	@echo "     zxcvbn-python (either install with 'pip3 install zxcvbn' or locally with 'make zxcvbn')"
-
-zxcvbn:
-	git submodule add https://github.com/dwolfhub/zxcvbn-python || git submodule init zxcvbn-python
-	@install -v -d "$(DESTDIR)$(EXTENSION_LIB)/"
-	cp -r "zxcvbn-python/zxcvbn/" "$(DESTDIR)$(EXTENSION_LIB)/"
+	@echo "     zxcvbn"
 
 install:
 	@install -v -d "$(DESTDIR)$(MANDIR)/man1"
@@ -49,4 +44,4 @@ lint:
 clean:
 	@rm -vrf tests/test-results/ tests/gnupg/random_seed
 
-.PHONY: zxcvbn install uninstall tests lint clean
+.PHONY: install uninstall tests lint clean

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ install:
 	@trap 'rm -f .audit.bash' EXIT; sed "s|/usr/lib|$(LIBDIR)|" "$(PROG).bash" > ".$(PROG).bash" && \
 	install -v -m 0755 ".$(PROG).bash" "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/$(PROG).bash"
 	@install -v -m 0755 "lib/$(PROG).py" "$(DESTDIR)$(EXTENSION_LIB)/$(PROG).py"
+	cp -r "zxcvbn-python/zxcvbn/" "$(DESTDIR)$(EXTENSION_LIB)/"
 	@install -v -m 0644 "pass-$(PROG).1" "$(DESTDIR)$(MANDIR)/man1/pass-$(PROG).1"
 	@echo
 	@echo "pass-$(PROG) is installed succesfully"

--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@ More reading:
 * `python-requests`
   - Debian/Ubuntu: `sudo apt-get install python3-requests`
   - OSX: `pip3 install requests`
-* `zxcvbn-python`
-  - `pip3 install zxcvbn` or `make zxcvbn`
+* `zxcvbn-python` (`pip3 install zxcvbn`)
 
 **From git**
 ```sh

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ More reading:
 
 **From git**
 ```sh
-git clone https://github.com/roddhjav/pass-audit/
+git clone --recurse-submodules https://github.com/roddhjav/pass-audit/
 cd pass-audit
 sudo make install  # For OSX: make install PREFIX=/usr/local
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 ## Description
 `pass audit` is a password-store extension for auditing your password repository.
+Passwords will be checked against the Python implementation of Dropbox'
+[`zxcvbn`][zxcvbn] algorithm and Troy Hunt's *Have I Been Pwned* Service.
 It supports safe breached password detection from [haveibeenpwned.com][HIBP]
 using a [K-anonymity][Kanonymity] method. Using this method, you do not need to
 (fully) trust the server that stores the breached password. You should read the
@@ -94,10 +96,12 @@ More reading:
 * `python-requests`
   - Debian/Ubuntu: `sudo apt-get install python3-requests`
   - OSX: `pip3 install requests`
+* `zxcvbn-python`
+  - `pip3 install zxcvbn` or `make zxcvbn`
 
 **From git**
 ```sh
-git clone --recurse-submodules https://github.com/roddhjav/pass-audit/
+git clone https://github.com/roddhjav/pass-audit/
 cd pass-audit
 sudo make install  # For OSX: make install PREFIX=/usr/local
 ```
@@ -129,10 +133,13 @@ gpg --verify pass-audit-0.1.tar.gz.asc
 ## Contribution
 Feedback, contributors, pull requests are all very welcome.
 
+### Contributors
+ * [Tobias Girstmair](https://gir.st/) (zxcvbn)
+
 
 ## License
 
-    Copyright (C) 2018  Alexandre PUJOL
+    Copyright (C) 2018  Alexandre PUJOL and Contributors
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -153,3 +160,4 @@ Feedback, contributors, pull requests are all very welcome.
 [pass]: https://www.passwordstore.org/
 [Kanonymity]: https://en.wikipedia.org/wiki/K-anonymity
 [HIBP]: https://haveibeenpwned.com/
+[zxcvbn]: https://blogs.dropbox.com/tech/2012/04/zxcvbn-realistic-password-strength-estimation/

--- a/lib/audit.py
+++ b/lib/audit.py
@@ -216,11 +216,11 @@ class PassAudit():
                 # extract "login:", "url:", etc.
                 split_line = line.split(':', 1)
                 if len(split_line) > 1:
-                    user_input.append(split_line[1])
+                    user_input += split_line[1].split()
             results = zxcvbn(password, user_inputs=user_input + path.split("/"))
             if results['score'] <= 2:
                 breached.append((path, password, results))
-            return breached
+        return breached
 
 
 def main(argv):

--- a/tests/00_pass.py
+++ b/tests/00_pass.py
@@ -67,7 +67,7 @@ class TestPassStore(setup.TestPass):
         """Testing: pass show password."""
         path = "Social/mastodon.social"
         password = "D<INNeT?#?Bf4%`zA/4i!/'$T"
-        self.assertEqual(self.store.show(path), password)
+        self.assertEqual(self.store.show(path).split('\n')[0], password)
 
 
 if __name__ == '__main__':

--- a/tests/10_audit.py
+++ b/tests/10_audit.py
@@ -39,7 +39,7 @@ class TestPassAudit(setup.TestPass):
         self.assertTrue(len(breached) == self.passwords_nb)
         for path, password, count in breached:
             self.assertIn(path, data)
-            self.assertTrue(data[path] == password)
+            self.assertTrue(data[path].split('\n')[0] == password)
             ref_index = int(path[-1:]) - 1
             self.assertTrue(ref_counts[ref_index] == count)
 


### PR DESCRIPTION
This PR extends `pass audit` to also flag passwords that are likely weak (using the python implementation of Dropbox's `zxcvbn`). 

 * In order to also compare against usernames, the whole password file will be read in (as opposed to only the first line), so I had to change the accessing of the passwords a bit. 
 * ~~as to not require the user to install the `zxcvbn` python library from pip, I've included it as a git submodule, which will be copied to `/usr/lib/password-store/audit` when `make install` is issued. That means, cloning now should either be done with `git clone --recurse-submodules` or the submodule needs to be otherwise initialized beforehand.~~ made optional
 * some more testing should be done before merging this, but I wanted to get some input before I continue.  ~~(I think I'm not getting all the weak passwords detected, but it's 5am already)~~ i had a `return` too far indented m(

example output:

```
  .  Auditing whole store - this may take some time
  w  Password breached: foobar from bar/foo has been breached 11063 time(s).
  w  Password breached: foofoo from testx has been breached 6668 time(s).
  w  Weak password detected: wkxjzdpl from zdpl/wkxj might be weak. Details: Score 1 (15000 guesses). The password is combined from the following parts: wkxj(dictionary) + zdpl(dictionary)
  w  Weak password detected: foofoo from testx might be weak. Details: Score 1 (2003.0 guesses). The password is combined from the following parts: foofoo(repeat)
 [x] Error: 2 passwords tested and 2 breached, 2 weak passwords found.
  .  You should update them with 'pass-update'.
```