### PR TITLE
Include passwords not located in subdirectory in checks

### DIFF
--- a/lib/audit.py
+++ b/lib/audit.py
@@ -138,7 +138,10 @@ class PasswordStore():
             paths = [path]
         else:
             paths = []
-            for file in glob.glob(prefix + '*/**/*.gpg', recursive=True):
+            pattern = self.prefix + '/**/*.gpg'
+            if path:
+                pattern = prefix + '*/**/*.gpg'
+            for file in glob.glob(pattern, recursive=True):
                 if not file[0] == '.':
                     file = os.path.splitext(file)[0]
                     file = file[len(self.prefix)+1:]

--- a/tests/10_audit.py
+++ b/tests/10_audit.py
@@ -32,7 +32,7 @@ class TestPassAudit(setup.TestPass):
 
     def test_password_pwned(self):
         """Testing: pass audit for password breached with K-anonymity method."""
-        ref_counts = [47205, 2, 103, 1218, 3303003, 75590, 357]
+        ref_counts = [51259, 3, 114, 1352, 3645804, 78773, 396]
         data = self._getdata("Password/pwned")
         audit = self.passaudit.PassAudit(data)
         breached = audit.password()

--- a/tests/20_pwned.py
+++ b/tests/20_pwned.py
@@ -31,9 +31,9 @@ class TestPwnedAPI(setup.TestPass):
         hash = '21BD12DC183F740EE76F27B78EB39C8AD972A757'
         hashes, counts = self.api.password_range(prefix)
         self.assertIn(hash, hashes)
-        self.assertTrue(counts[hashes.index(hash)] == 47205)
+        self.assertTrue(counts[hashes.index(hash)] == 51259)
         self.assertTrue(len(hashes) == len(counts))
-        self.assertTrue(len(hashes) == 475)
+        self.assertTrue(len(hashes) == 527)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When checking the entire store, include passwords located in the root of the
password store.

Fixes #8.