### PR TITLE
 Ignore the first line of a file when parsing user input

### DIFF
--- a/lib/audit.py
+++ b/lib/audit.py
@@ -212,7 +212,7 @@ class PassAudit():
             payload_lines = payload.split('\n')
             password = payload_lines[0]
             user_input = []
-            for line in payload_lines:
+            for line in payload_lines[1:]:
                 # extract "login:", "url:", etc.
                 split_line = line.split(':', 1)
                 if len(split_line) > 1:

--- a/tests/10_audit.py
+++ b/tests/10_audit.py
@@ -32,7 +32,7 @@ class TestPassAudit(setup.TestPass):
 
     def test_password_pwned(self):
         """Testing: pass audit for password breached with K-anonymity method."""
-        ref_counts = [47205, 2, 103, 1218, 3303003, 75590, 357]
+        ref_counts = [51259, 3, 114, 1352, 3645804, 78773, 396]
         data = self._getdata("Password/pwned")
         audit = self.passaudit.PassAudit(data)
         breached = audit.password()

--- a/tests/20_pwned.py
+++ b/tests/20_pwned.py
@@ -31,9 +31,9 @@ class TestPwnedAPI(setup.TestPass):
         hash = '21BD12DC183F740EE76F27B78EB39C8AD972A757'
         hashes, counts = self.api.password_range(prefix)
         self.assertIn(hash, hashes)
-        self.assertTrue(counts[hashes.index(hash)] == 47205)
+        self.assertTrue(counts[hashes.index(hash)] == 51259)
         self.assertTrue(len(hashes) == len(counts))
-        self.assertTrue(len(hashes) == 475)
+        self.assertTrue(len(hashes) == 527)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The first line of a file contains the password and must be ignored, when user
input is parsed. Otherwise, if the password contains a ':' a part of the
password will be added to `zxcvbn`s dictionary, leading to false negatives.

Fixes #9.