### PR TITLE
Add verbose output

### DIFF
--- a/pass_audit.py
+++ b/pass_audit.py
@@ -307,8 +307,7 @@ def sanitychecks(arg, msg):
 def report(msg, data, breached, weak):
     """Print final report."""
     if not breached and not weak:
-        msg.success("None of the %s passwords tested are breached." % len(data))
-        msg.message("However, it does not mean they are strong.")
+        msg.success("None of the %s passwords tested are breached or weak." % len(data))
     else:
         msg.error("%d passwords tested and %d breached, %d weak passwords found."
                   % (len(data), len(breached), len(weak)))

--- a/pass_audit.py
+++ b/pass_audit.py
@@ -215,26 +215,27 @@ class PwnedAPI():
 
 class PassAudit():
 
-    def __init__(self, data):
+    def __init__(self, data, msg):
         self.data = data
+        self.msg = msg
 
     def password(self):
         """K-anonimity password breach detection on haveibeenpwned.com."""
         # Generate the list of hashes and prefixes to query.
+        self.msg.verbose("Checking for breached passwords [hibp]:")
         data = []
         prefixes = []
+        buckets = dict()
         for path, payload in self.data.items():
+            self.msg.verbose("[hibp] %s" % path)
             password = payload.split('\n')[0]
             phash = hashlib.sha1(password.encode("utf8")).hexdigest().upper()
             prefix = phash[0:5]
             data.append((path, payload, phash, prefix))
             if prefix not in prefixes:
                 prefixes.append(prefix)
-
-        # Query the server and collect the buckets
-        buckets = dict()
-        for prefix in prefixes:
-            buckets[prefix] = PwnedAPI.password_range(prefix)
+                # Query the server and collect the buckets
+                buckets[prefix] = PwnedAPI.password_range(prefix)
 
         # Compare the data and return the breached passwords.
         breached = []
@@ -248,8 +249,10 @@ class PassAudit():
 
     def zxcvbn(self):
         """Password strength estimaton usuing Dropbox' zxcvbn"""
+        self.msg.verbose("Checking for weak passwords [zxcvbn]:")
         breached = []
         for path, payload in self.data.items():
+            self.msg.verbose("[zxcvbn] %s" % path)
             payload_lines = payload.split('\n')
             password = payload_lines[0]
             user_input = []
@@ -320,21 +323,23 @@ def main(argv):
     (store, paths) = sanitychecks(arg, msg)
 
     # Read data from the password store.
+    msg.verbose("Reading password store [init]:")
     data = dict()
     for path in paths:
         try:
+            msg.verbose("[init] %s" % path)
             data[path] = store.show(path)
         except PasswordStoreError as e:
             msg.warning("Imposible to read %s from the password store: %s"
                         % (path, e))
 
     # Start the audit of the password store
-    audit = PassAudit(data)
+    audit = PassAudit(data, msg)
     breached = audit.password()
+    weak = audit.zxcvbn()
     for path, payload, count in breached:
         msg.warning("Password breached: %s from %s has been breached %s time(s)."
                     % (payload, path, count))
-    weak = audit.zxcvbn()
     for path, payload, details in weak:
         msg.warning("Weak password detected: %s from %s might be weak. %s"
                     % (payload, path, zxcvbn_parse(details)))

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -22,11 +22,12 @@ from tests.commons import TestPass
 
 class TestPassAudit(TestPass):
     passwords_nb = 7
+    msg = pass_audit.Msg()
 
     def test_password_notpwned(self):
         """Testing: pass audit for password not breached with K-anonymity method."""
         data = self._getdata("Password/notpwned")
-        audit = pass_audit.PassAudit(data)
+        audit = pass_audit.PassAudit(data, self.msg)
         breached = audit.password()
         self.assertTrue(len(breached) == 0)
 
@@ -34,7 +35,7 @@ class TestPassAudit(TestPass):
         """Testing: pass audit for password breached with K-anonymity method."""
         ref_counts = [51259, 3, 114, 1352, 3645804, 78773, 396]
         data = self._getdata("Password/pwned")
-        audit = pass_audit.PassAudit(data)
+        audit = pass_audit.PassAudit(data, self.msg)
         breached = audit.password()
         self.assertTrue(len(breached) == self.passwords_nb)
         for path, password, count in breached:


### PR DESCRIPTION
Auditing a password repository can take a significant amount of time. I added some verbose output to be able to see that pass is actually doing something. Basically this boils down to printing any password path that pass-audit is currently working on prefixed by `[init]`, `[hibp]` or `[zxcvbn]` depending on what pass-audit is currently doing with the password.

The output that is emitted when the `--verbose` flag is not set has not been changed.