### PR TITLE
fix glitches in Debian install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ yay -S pass-audit  # or your preferred AUR install method
 my GPG key: [`06A26D531D56C42D66805049C5469996F0DF68EC`][keys].
 ```sh
 wget -qO - https://pkg.pujol.io/debian/gpgkey | sudo apt-key add -
-sudo echo 'deb https://pkg.pujol.io/debian/repo all main' > /etc/apt/sources.list.d/pkg.pujol.io.list
+echo 'deb [arch=amd64] https://pkg.pujol.io/debian/repo all main' | sudo tee /etc/apt/sources.list.d/pkg.pujol.io.list
 sudo apt-get update
 sudo apt-get install pass-extension-audit
 ```


### PR DESCRIPTION
Hey, first of all thanks for the tool!

When trying to install it on debian as suggested in the README, I found two glitches that could be improved:

The repo is amd64 only, so tell apt that the debian repo is amd64-only, so it doesn't issue a notice on every apt update (for multiarch setups).
Furthermore, echo with or without sudo, the piping is bound to the current user of the shell, but tee with root-privileges may write to /etc.