### PR TITLE
Update incorrect program name to audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ security:
 
 clean:
 	@rm -rf .coverage .mypy_cache .pybuild .ropeproject build \
-		debian/.debhelper debian/debhelper* debian/pass-extension-import* \
+		debian/.debhelper debian/debhelper* debian/pass-extension-audit* \
 		dist *.egg-info htmlcov */__pycache__/ __pycache__ \
 		session.baseline.sqlite session.sqlite \
 		tests/gnupg/random_seed tests/test-results/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ using a [K-anonymity][Kanonymity] method. Using this method, you do not need to
 ## Usage
 
 ```
-usage: pass import [-h] [-V] [-v | -q] [pass-names]
+usage: pass audit [-h] [-V] [-v | -q] [pass-names]
 
  A pass extension for auditing your password repository. It supports safe
  breached password detection from haveibeenpwned.com using K-anonymity method

--- a/pass_audit/__main__.py
+++ b/pass_audit/__main__.py
@@ -37,7 +37,7 @@ class ArgParser(ArgumentParser):
         epilog = "More information may be found in the pass-audit(1) man page."
 
         super(ArgParser,
-              self).__init__(prog='pass import',
+              self).__init__(prog='pass audit',
                              description=description,
                              formatter_class=RawDescriptionHelpFormatter,
                              epilog=epilog)


### PR DESCRIPTION
Found a few leftover references to `pass-import`.
These are corrected from `import` to `audit`.