### PR TITLE
Fix manpage whatis entry

### DIFF
--- a/pass-audit.1
+++ b/pass-audit.1
@@ -1,7 +1,7 @@
 .TH "pass-audit" 1 "April 2018" "pass-audit"
 
 .SH NAME
-\fBpass audit\fP - A \fIpass\fP(1) extension for auditing your password repository.
+\fBpass-audit\fP \- A \fIpass\fP(1) extension for auditing your password repository.
 
 
 .SH SYNOPSIS


### PR DESCRIPTION
First, thanks a lot for this nice tool. I'm not using it often but it comes in handy when I need it.

The current manpage has a problem in the NAME entry. According to the specifications, the program name must not contain any whitespace characters.

You can check that by using the `lexgrog` command line (from `man-db` package in Debian-like distributions):
```bash
$ lexgrog pass-audit.1
pass-audit.1: parse failed
```

with this fix:
```bash
$ lexgrog pass-audit.1 
pass-audit.1: "pass-audit - A pass(1) extension for auditing your password repository."
```

Note: this comes from a [lintian check](https://lintian.debian.org/tags/bad-whatis-entry)