### PR TITLE
Add option to limit checks to specific filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ using a [K-anonymity][Kanonymity] method. Using this method, you do not need to
 ## Usage
 
 ```
-usage: pass audit [-h] [-V] [-v | -q] [pass-names]
+usage: pass audit [-f|--filename filename] [-h] [-V] [-v | -q] [pass-names]
 
  A pass extension for auditing your password repository. It supports safe
  breached password detection from haveibeenpwned.com using K-anonymity method
@@ -31,6 +31,7 @@ positional arguments:
   pass-names     Path(s) to audit in the password store, If empty audit the full store.
 
 optional arguments:
+  -f, --filename filename Check only passwords with this filename.gpg
   -h, --help     show this help message and exit
   -V, --version  Show the program version and exit.
   -v, --verbose  Set verbosity level, can be used more than once.

--- a/completion/pass-audit.bash
+++ b/completion/pass-audit.bash
@@ -3,7 +3,7 @@
 PASSWORD_STORE_EXTENSION_COMMANDS+=(audit)
 
 __password_store_extension_complete_audit() {
-	local args=(-h --help -q --quiet -v --verbose -V --version)
+	local args=(-f --filename -h --help -q --quiet -v --verbose -V --version)
 	COMPREPLY+=($(compgen -W "${args[*]}" -- ${cur}))
 	_pass_complete_entries
 	compopt -o nospace

--- a/completion/pass-audit.zsh
+++ b/completion/pass-audit.zsh
@@ -3,6 +3,7 @@
 
 _pass-audit () {
 	_arguments : \
+        {-f,--filename}'[check only passwords with this filename]' \
 		{-h,--help}'[display help information]' \
 		{-V,--version}'[display version information]' \
 		{-q,--quiet}'[be quiet]' \

--- a/pass-audit.1
+++ b/pass-audit.1
@@ -1,11 +1,11 @@
-.TH "pass-audit" 1 "April 2018" "pass-audit"
+.TH "pass-audit" 1 "December 2021" "pass-audit"
 
 .SH NAME
 \fBpass audit\fP - A \fIpass\fP(1) extension for auditing your password repository.
 
 
 .SH SYNOPSIS
-\fBpass audit\fP [-h] [-V] [paths]
+\fBpass audit\fP [-f|--filename filename] [-h] [-V] [paths]
 
 .SH DESCRIPTION
 \fBpass audit\fP is a password store extension for auditing your password
@@ -19,6 +19,10 @@ using K-anonymity method and password strength estimation by Dropbox' zxcvbn.
 
 
 .SH OPTIONS
+
+.TP
+\fB\-f\fB, \-\-filename\fR \fIfilename\fR
+Check only passwords from file with name \fIfilename\fR.gpg.
 
 .TP
 \fB\-q\fB, \-\-quiet\fR

--- a/pass_audit/__main__.py
+++ b/pass_audit/__main__.py
@@ -52,6 +52,7 @@ class ArgParser(ArgumentParser):
         self.add_argument('-V', '--version', action='version',
                           version='%(prog)s ' + __version__,
                           help='Show the program version and exit.')
+        self.add_argument('-f', '--filename', type=str, default="*", help="""Check only passwords with this filename""")
         group = self.add_mutually_exclusive_group()
         group.add_argument('-v', '--verbose', action='count', default=0,
                            help='Set verbosity level, '
@@ -75,7 +76,7 @@ def setup():
     if not store.isvalid():
         msg.die('invalid user ID, password access aborted.')
 
-    paths = store.list(arg.paths)
+    paths = store.list(arg.paths, arg.filename)
     if not paths:
         msg.die("%s is not in the password store." % arg.paths)
 

--- a/pass_audit/passwordstore.py
+++ b/pass_audit/passwordstore.py
@@ -81,14 +81,14 @@ class PasswordStore():
     def prefix(self, value):
         self.env['PASSWORD_STORE_DIR'] = value
 
-    def list(self, path=''):
+    def list(self, path='', filename='*'):
         """List the paths in the password store repository."""
         prefix = os.path.join(self.prefix, path)
         if os.path.isfile(prefix + '.gpg'):
             paths = [path]
         else:
             paths = []
-            for ppath in Path(prefix).rglob('*.gpg'):
+            for ppath in Path(prefix).rglob('{}.gpg'.format(filename)):
                 file = os.sep + str(ppath)[len(self.prefix) + 1:]
                 if "%s." % os.sep not in file:
                     file = os.path.splitext(file)[0][1:]

--- a/tests/test_pass.py
+++ b/tests/test_pass.py
@@ -104,6 +104,15 @@ class TestExportPassShow(tests.Test):
         ref = ['Emails/WS/dpbx@fner.ws', 'Emails/WS/dpbx@mnyfymt.ws']
         self.assertEqual(self.store.list('Emails/WS'), ref)
 
+    def test_pass_list_limit_filename(self):
+        """Testing: pass list **/<filename>"""
+        prefix = tests.assets + 'audit-store'
+        store = PasswordStore(prefix)
+        ref = ['Password/good/1', 'Password/notpwned/1', 'Password/pwned/1']
+        self.assertEqual(store.list(filename='1'), ref)
+        ref = ['dummy']
+        self.assertEqual(store.list(filename='dummy'), ref)
+
     def test_pass_show(self):
         """Testing: pass show Social/mastodon.social."""
         path = "Social/mastodon.social"


### PR DESCRIPTION
This adds an option to pass-audit command to allow checking only files with a specific filename.

I'm using `pass` with a hierarchical structure (Website/<fqdn.tld>/{login,password}). This MR would allow to only check for files named `password.gpg` using:
```bash
$ pass audit -f password Subfolder/
```