### PR TITLE
remove shebang from non executable `__main__.py` file

### DIFF
--- a/pass_audit/__main__.py
+++ b/pass_audit/__main__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*
 # pass audit - Password Store Extension (https://www.passwordstore.org/)
 # Copyright (C) 2018-2022 Alexandre PUJOL <alexandre@pujol.io>.


### PR DESCRIPTION
Found using `rpmlint` on the fedora package