### PR TITLE
Add ignoring password entires in auditing

### DIFF
--- a/pass_audit/__main__.py
+++ b/pass_audit/__main__.py
@@ -81,9 +81,19 @@ def setup():
     if not store.isvalid():
         msg.die('invalid user ID, password access aborted.')
 
-    paths = store.list(arg.paths, arg.name)
-    if not paths:
+    paths_raw = store.list(arg.paths, arg.name)
+    paths = []
+
+    if not paths_raw:
         msg.die(f"{arg.paths} is not in the password store.")
+
+    with open(os.path.join(store.prefix, ".pass-audit-ignore"), "r") as ignore:
+        ignore_paths = ignore.read()
+
+        for ignore_path in ignore_paths.split("\n"):
+            for path in paths_raw:
+                if not path.startswith(ignore_path):
+                    paths.append(path)
 
     return msg, store, paths
 


### PR DESCRIPTION
Because of the fact that `password-store` stores passwords (secrets) in plaintext, it's a good idea that a note written there would be flagged quickly and annoy you. So it's a safe bet to add an option to ignore passwords, so this Pull Request adds  `.pass-audit-ignore` as a file that can be created in the password store directory to ignore passwords with the prefix. For example, ignoring passwords in a dir is easy. For example, here is one that ignores passwords in a directory called test:
```
Test/
```