### PR TITLE
Two tiny fixes

### DIFF
--- a/pass_audit/audit.py
+++ b/pass_audit/audit.py
@@ -86,9 +86,13 @@ class PassAudit():
             user_input = list(entry.values()) + path.split(os.sep)
             if password in user_input:
                 user_input.remove(password)
-            results = zxcvbn(password, user_inputs=user_input)
-            if results['score'] <= 2:
-                weak.append((path, password, results))
+            try:
+                results = zxcvbn(password, user_inputs=user_input)
+            except ValueError:
+                pass
+            else:
+                if results['score'] <= 2:
+                    weak.append((path, password, results))
         return weak
 
     def duplicates(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ version = attr: pass_audit.__version__
 description = A pass extension for auditing your password repository.
 long_description = file: README.md
 long_description_content_type = text/markdown
-license = GPL3
+license = GPL-3.0-or-later
 url = https://github.com/roddhjav/pass-audit
 author = Alexandre Pujol
 author_email = alexandre@pujol.io
@@ -25,7 +25,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console
     Intended Audience :: End Users/Desktop
-    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
     Operating System :: MacOS :: MacOS X
     Operating System :: POSIX
     Operating System :: POSIX :: BSD


### PR DESCRIPTION
* set project.license to the right value
  References: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

* skip too long password
  `zxcvbn` has limit 72 characters for the length of password; instead of failing the whole script, just ignore this password.